### PR TITLE
FIX: dev integration requires kubectl use context and use grafana url…

### DIFF
--- a/mk/deploy.mk
+++ b/mk/deploy.mk
@@ -27,12 +27,15 @@ terraform_init:
 
 .PHONY: terraform_plan
 # plan the terraform provisioning in the cluster
-terraform_plan: build_images terraform_init
+terraform_plan: terraform_init
 	$(MAKE) -C $(infrastructure_repository)/$(env_folder) terraform_plan
 
 .PHONY: terraform_apply
 # apply the terraform provisoining in the cluster
-terraform_apply: build_images terraform_init
+terraform_apply: terraform_init
+	if [[ "$$env_name" == "minikube" ; then \
+	$(MAKE) build_images; \
+	fi
 	$(MAKE) -C $(infrastructure_repository)/$(env_folder) terraform_apply
 
 .PHONY: build_images

--- a/mk/gcloud.mk
+++ b/mk/gcloud.mk
@@ -12,6 +12,10 @@ project_start:
 
 gcloud_dashboard:
 	xdg-open https://console.cloud.google.com/kubernetes/workload?project=serlo-dev&workload_list_tablesize=50 2>/dev/null >/dev/null &
-	
+
+kubectl_use_context:
+	kubectl config use-context gke_serlo-$(env_name)_europe-west3-a_serlo-$(env_name)-cluster
+
+
 tools_run_postgres_cloud_sql_proxy:
 	$(MAKE) -C $(infrastructure_repository)/live/dev run-postgres-cloud-sql-proxy

--- a/mk/minikube.mk
+++ b/mk/minikube.mk
@@ -28,3 +28,7 @@ minikube_delete:
 minikube_dashboard:
 	$(MAKE) -C $(infrastructure_repository)/minikube minikube_dashboard
 
+.PHONY:
+kubectl-use-context:
+	kubectl config use-context minikube
+

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -4,6 +4,6 @@
 
 .PHONY: project_smoketest
 # run smoketest for kpi project
-project_smoketest:
+project_smoketest: kubectl_use_context
 	$(MAKE) -C smoketest
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -10,24 +10,24 @@ tools_container_log_%:
 
 .PHONY: tools_aggregator_log
 # show the data aggregator log
-tools_aggregator_log: tools_container_log_aggregator
+tools_aggregator_log: kubectl_use_context tools_container_log_aggregator
 
 .PHONY: tools_importer_log
 # show the database importer log
-tools_importer_log: tools_container_log_mysql-importer
+tools_importer_log: kubectl_use_context tools_container_log_mysql-importer
 
 .PHONY: tools_dbdump_log
 # show the database dump log
-tools_dbdump_log: tools_container_log_dbdump
+tools_dbdump_log: kubectl_use_context tools_container_log_dbdump
 
 .PHONY: tools_dbsetup_log
 # show the athene2 content provider log
-tools_dbsetup_log: tools_container_log_dbsetup
+tools_dbsetup_log: kubectl_use_context tools_container_log_dbsetup
 
 .PHONY: tools_psql_shell
 .ONESHELL:
 # open a postgres shell
-tools_psql_shell:
+tools_psql_shell: kubectl_use_context
 	pod=$$(kubectl get pods --namespace=kpi | grep postgres | awk '{ print $$1 }')
 	kubectl exec -it $$pod --namespace=kpi -- su - postgres -c psql
 

--- a/smoketest/grafana_test.go
+++ b/smoketest/grafana_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 )
 
-var grafanaURL = "https://stats.serlo.local/login"
+var grafanaURL = fmt.Sprintf("%s/login", os.Getenv("grafana_host"))
 
 //TestGrafanaApp test if grafana is working
 func TestGrafanaApp(t *testing.T) {


### PR DESCRIPTION
Added kubectl_use_context and called to ensure we are running the kubectl commands against the right cluster.

Fixed the smoketest that was using a hardcoded grafana host.